### PR TITLE
README : Fix typo in namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install-Package WindowsInput
 ### Run Notepad using the Keyboard...
 ````csharp
 public async Task RunNotepad() {
-    await Windowsinput.Simulate.Events()
+    await WindowsInput.Simulate.Events()
         //Hold Windows Key+R
         .ClickChord(KeyCode.LWin, KeyCode.R).Wait(1000)
 


### PR DESCRIPTION
I discovered this package today and it is really helpful, but when I tried to use code in readme I had confusing compiling error because of a typo.

This commit fixes this case typo in namespace.

